### PR TITLE
gdetect_write block write skipping bug

### DIFF
--- a/gdetect/gdetect_write.m
+++ b/gdetect/gdetect_write.m
@@ -68,7 +68,7 @@ loc_f = loc_feat(model, pyra.num_levels);
 write_block = false(model.numblocks, 1);
 for i = 1:model.numblocks
   all_zero = all(model.blocks(i).w == 0);
-  write_block(i) = ~(model.blocks(i).learn == 0 && all_zero == 0);
+  write_block(i) = ~(model.blocks(i).learn == 0 && all_zero == 1);
 end
 
 count = 0;


### PR DESCRIPTION
I ran into a small bug for the case when you disable learning for a block after you've already learned some parameters for it.  gdetect_write sometimes fails to write these blocks.

The scores computed by the fv_cache will not match the scores computed in the poslatent step since some blocks will be incorrectly 0 in the cache.  When the hinge loss is checked, the fv_cache scores might be higher than the relabeled positives and so the outer relabeling loop will terminate.

Your comment is correct, but the code doesn't match.  
