### PR TITLE
Simple TBB-based parallelization for the cascade. Small improvements with little effort.

### DIFF
--- a/compile.m
+++ b/compile.m
@@ -1,4 +1,4 @@
-function compile(opt, verb, mex_file)
+function compile(opt, verb, use_tbb_for_cascades, mex_file)
 % Build MEX source code.
 %   All compiled binaries are placed in the bin/ directory.
 %
@@ -9,6 +9,7 @@ function compile(opt, verb, mex_file)
 % Arguments
 %   opt   Compile with optimizations (default: on)
 %   verb  Verbose output (default: off)
+%   use_tbb_for_cascades Parallelize cascades using TBB (default: off)
 
 % AUTORIGHTS
 % -------------------------------------------------------
@@ -36,6 +37,10 @@ if nargin < 2
   verb = false;
 end
 
+if nargin < 3
+  use_tbb_for_cascades = false;
+end
+
 % Start building the mex command
 mexcmd = 'mex -outdir bin';
 
@@ -57,11 +62,11 @@ end
 mexcmd = [mexcmd ' CXXFLAGS="\$CXXFLAGS -Wall"'];
 mexcmd = [mexcmd ' LDFLAGS="\$LDFLAGS -Wall"'];
 
-if nargin < 3
+if nargin < 4
   % Build feature vector cache code
   fv_compile(opt, verb);
   % Build the star-cascade code
-  cascade_compile(opt, verb);
+  cascade_compile(opt, verb, use_tbb_for_cascades);
 
   eval([mexcmd ' features/resize.cc']);
   eval([mexcmd ' features/features.cc']);

--- a/demo_cascade.m
+++ b/demo_cascade.m
@@ -20,7 +20,7 @@ function demo_cascade()
 startup;
 
 fprintf('compiling the code...');
-compile;
+compile(true,false,false); %TBB disabled by default
 fprintf('done.\n\n');
 
 fprintf(['\n\n' ...

--- a/train/split_occ.m
+++ b/train/split_occ.m
@@ -1,0 +1,32 @@
+function spos = split_occ(pos, n,weight)
+% Split examples based on aspect ratio and occlusion.
+%   spos = split(pos, n)
+% 
+%   Produces aspect ratio clusters for training mixture models
+%
+% Return value
+%   spos    Cell i holds the indices from pos for the i-th cluster
+%
+% Arguments
+%   pos     Positive examples from pascal_data.m
+%   n       Number of aspect ratio clusters
+% Uses VLFEAT
+
+h = [pos(:).y2]' - [pos(:).y1]' + 1;
+w = [pos(:).x2]' - [pos(:).x1]' + 1;
+aspects = h ./ w;
+occs = reshape([pos(:).occode],[7,length(pos)])';
+occs(:,2:3)=occs(:,2:3)+repmat(occs(:,6)*.5,1,2);
+occs(:,4:5)=occs(:,4:5)+repmat(occs(:,7)*.5,1,2);
+occs = occs(:,2:5);
+
+if nargin <3 
+    weight=1;
+end
+
+weight = weight*mean(aspects)/mean(arrayfun(@(idx) norm(occs(idx,:)), 1:size(occs,1)));
+feat=[aspects occs*weight];
+[C A] = vl_kmeans(feat',n);
+for i = 1:n
+  spos{i} = pos(A==i);
+end


### PR DESCRIPTION
I planned on training DPMs with quite many components and I noticed that the cascade code was not parallelized so I thought that I would throw in a few minutes for a simple parallelisation. It is in no way optimal, but rather a "small improvement with little effort" thing. Anyways, someone else might find it useful too so that's why I created this pull request.

Parallelizes over scales by default, but can parallelize over components (currently via an ifdef flag in cascade.cc). Gives about 50% speedup on a dual-core (4 virtual cores) processor for two of the models in the demo_cascade example, but only 10% for the last one. Haven't tried it on a machine with more cores yet, but I expect the that the model complexity needs to be higher (e.g. more components) for bigger gains.
